### PR TITLE
fixes compilation errors

### DIFF
--- a/simple-cam.cpp
+++ b/simple-cam.cpp
@@ -28,7 +28,7 @@ static void requestComplete(Request *request)
 	if (request->status() == Request::RequestCancelled)
 		return;
 
-	const std::map<Stream *, FrameBuffer *> &buffers = request->buffers();
+	const Request::BufferMap &buffers = request->buffers();
 
 	for (auto bufferPair : buffers) {
 		// (Unused) Stream *stream = bufferPair.first;
@@ -70,7 +70,7 @@ static void requestComplete(Request *request)
 
 	for (auto it = buffers.begin(); it != buffers.end(); ++it)
 	{
-		Stream *stream = it->first;
+		const Stream *stream = it->first;
 		FrameBuffer *buffer = it->second;
 
 		request->addBuffer(stream, buffer);


### PR DESCRIPTION
Fixes two compilation errors against the latest libcamera 
commit (de20029a582a71a87d99388a62fb63c86e85028a) 

Tested on Raspbian GNU/Linux 10 (buster)
